### PR TITLE
get important headers

### DIFF
--- a/src/wurfl.rs
+++ b/src/wurfl.rs
@@ -610,6 +610,11 @@ impl Wurfl {
         }
         return None;
     }
+
+    pub fn get_important_headers(&self) -> &HashMap<String, CString> {
+        return &self.important_header_cstring_names;
+    }
+
 }
 // END UPDATER METHODS ------------------------------------------------------------------------
 


### PR DESCRIPTION
added a public function to get import headers, here is example of headers

Important headers {"sec-ch-ua-platform": "Sec-CH-UA-Platform", "sec-ch-ua-arch": "Sec-CH-UA-Arch", "sec-ch-ua-model": "Sec-CH-UA-Model", "sec-ch-ua-platform-version": "Sec-CH-UA-Platform-Version", "x-ucbrowser-device-ua": "X-UCBrowser-Device-UA", "user-agent": "User-Agent", "cast-device-capabilities": "CAST-DEVICE-CAPABILITIES", "sec-ch-ua": "Sec-CH-UA", "x-requested-with": "X-Requested-With", "sec-ch-ua-full-version": "Sec-CH-UA-Full-Version", "sec-ch-ua-full-version-list": "Sec-CH-UA-Full-Version-List", "x-operamini-phone-ua": "X-OperaMini-Phone-UA", "sec-ch-ua-mobile": "Sec-CH-UA-Mobile", "accept-encoding": "Accept-Encoding", "device-stock-ua": "Device-Stock-UA"}